### PR TITLE
Change to use HarvestMigrateSourceList class

### DIFF
--- a/dkan_harvest_ckan.migrate.inc
+++ b/dkan_harvest_ckan.migrate.inc
@@ -26,7 +26,7 @@ class HarvestMigrationCKAN extends HarvestMigration {
     $this->itemUrl = drupal_realpath($this->dkanHarvestSource->getCacheDir()) .
             '/:id';
 
-    $this->source = new MigrateSourceList(
+    $this->source = new HarvestMigrateSourceList(
             new HarvestList($this->dkanHarvestSource->getCacheDir()),
             new MigrateItemJSON($this->itemUrl),
             $this->getCkanDatasetFields(),
@@ -215,7 +215,7 @@ class HarvestMigrationCKANPackages extends HarvestMigrationCKAN {
     $this->itemUrl = str_replace("/package_list", '/' , $arguments['dkan_harvest_source']->uri)
             . 'package_show?id=:id';
     
-    $this->source = new MigrateSourceList(
+    $this->source = new HarvestMigrateSourceList(
             new HarvestList($this->dkanHarvestSource->getCacheDir()),
             new CKANItemJSON($this->itemUrl),
             $this->getCkanDatasetFields(),
@@ -238,7 +238,7 @@ class HarvestMigrationCKANDataset extends HarvestMigrationCKAN {
     parent::__construct($arguments);
     $this->itemUrl = $arguments['dkan_harvest_source']->uri . '/:id';
     
-    $this->source = new MigrateSourceList(
+    $this->source = new HarvestMigrateSourceList(
             new HarvestList($this->dkanHarvestSource->getCacheDir()),
             new MigrateItemJSON($this->itemUrl),
             $this->getCkanDatasetFields(),


### PR DESCRIPTION
DKAN Harvest changed to use the HarvestMigrateSourceList class to be able to provide support for the `--limit` option in drush commands. This PR updates `dkan_harvest_ckan` to accommodate the upstream change.